### PR TITLE
hex PSK, PAN ID, direct join

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 // vim: set shiftwidth=2 tabstop=2 expandtab:
+#include <boost/algorithm/hex.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/asio.hpp>
 #include <boost/format.hpp>
@@ -679,6 +680,9 @@ int main(int argc, const char** argv) {
     ("psk",
      boost::program_options::value<std::string>()->default_value("AqaraHub"),
      "Zigbee Network pre-shared key. Maximum 16 characters, will be truncated when longer")
+    ("pskhex",
+     boost::program_options::value<std::string>(),
+     "Zigbee Network pre-shared key in hexadecimal notation, overrides psk parameter")
     ("cluster-info",
      boost::program_options::value<std::string>()->default_value("../clusters.info"),
      "Boost property-tree info file containing cluster, attribute, and command information")
@@ -753,6 +757,14 @@ int main(int argc, const char** argv) {
   std::string presharedkey_str(variables["psk"].as<std::string>());
   std::array<uint8_t, 16> presharedkey;
   presharedkey.fill(0);
+  if (variables.count("pskhex")) {
+    try {
+      presharedkey_str = boost::algorithm::unhex(variables["pskhex"].as<std::string>());
+    } catch (...) {
+      LOG("Main", critical) << "Unable to parse hexadecimal PSK";
+      return EXIT_FAILURE;
+    }
+  }
   std::copy_n(presharedkey_str.begin(),
               std::min(presharedkey.size(), presharedkey_str.size()),
               presharedkey.begin());

--- a/src/znp/znp_api.cpp
+++ b/src/znp/znp_api.cpp
@@ -130,6 +130,20 @@ stlab::future<ShortAddress> ZnpApi::ZdoMgmtLeave(ShortAddress DstAddr,
         return std::get<0>(retval);
       });
 }
+stlab::future<uint16_t> ZnpApi::ZdoMgmtDirectJoin(uint16_t DstAddr,
+                                                  IEEEAddress DeviceAddress) {
+  return WaitAfter(RawSReq(ZdoCommand::MGMT_DIRECT_JOIN_REQ,
+                           znp::EncodeT(DstAddr, DeviceAddress))
+                       .then(CheckOnlyStatus),
+                   ZnpCommandType::AREQ, ZdoCommand::MGMT_DIRECT_JOIN_RSP)
+      .then(znp::DecodeT<uint16_t, ZnpStatus>)
+      .then([](std::tuple<uint16_t, ZnpStatus> retval) {
+        if (std::get<1>(retval) != ZnpStatus::Success) {
+          throw std::runtime_error("DirectJoin returned non-success status");
+        }
+        return std::get<0>(retval);
+      });
+}
 stlab::future<uint16_t> ZnpApi::ZdoMgmtPermitJoin(AddrMode addr_mode,
                                                   uint16_t dst_address,
                                                   uint8_t duration,

--- a/src/znp/znp_api.h
+++ b/src/znp/znp_api.h
@@ -56,6 +56,8 @@ class ZnpApi {
   stlab::future<ShortAddress> ZdoMgmtLeave(ShortAddress DstAddr,
                                            IEEEAddress DeviceAddr,
                                            uint8_t remove_rejoin);
+  stlab::future<uint16_t> ZdoMgmtDirectJoin(uint16_t DstAddr,
+                                            IEEEAddress DeviceAddress);
   stlab::future<uint16_t> ZdoMgmtPermitJoin(AddrMode addr_mode,
                                             uint16_t dst_address,
                                             uint8_t duration,


### PR DESCRIPTION
This is a series of patches that add functionality to
- pass the PSK in hex notation (which allows me to pass the zigbee-shepherd default PSK which contains a NUL byte),
- configure the PAN ID on command line (also changes the default PAN ID from last 16 bit of IEEE address of the coordinator to 0xFFFF which lets the coordinator decide),
- add support for ZDO direct join call, which allowed me to "recollect" some devices that the coordinator forgot about (do to a full flash reset) that I have a hard time to push into join mode themselves (Philips Hue, which need a Philips remote control via touchlink to have them rejoin)