### PR TITLE
Initial try to crosscompile AqaraHub for Raspberry Pi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:buster-slim
+RUN apt update && apt install -y --no-install-recommends curl tar xz-utils cmake make git perl bzip2 pkg-config build-essential
+RUN curl -kL http://releases.linaro.org/components/toolchain/binaries/6.5-2018.12/arm-linux-gnueabihf/gcc-linaro-6.5.0-2018.12-x86_64_arm-linux-gnueabihf.tar.xz | tar -Jxf -
+
+ENV PATH="/gcc-linaro-6.5.0-2018.12-x86_64_arm-linux-gnueabihf/bin/:${PATH}"
+RUN mkdir -p /usr/src/
+WORKDIR /usr/src
+
+RUN curl -kL https://www.openssl.org/source/openssl-1.1.1a.tar.gz | tar -zxf -
+RUN curl -kL https://dl.bintray.com/boostorg/release/1.69.0/source/boost_1_69_0.tar.bz2 | tar -jxf -
+RUN GIT_SSL_NO_VERIFY=1 git clone --recursive https://github.com/Frans-Willem/AqaraHub
+
+WORKDIR /usr/src/openssl-1.1.1a
+RUN CROSS_COMPILE=arm-linux-gnueabihf- ./Configure linux-armv4 --prefix=/opt/arm/
+RUN make -j`nproc`
+RUN make install_sw
+
+
+WORKDIR /usr/src/
+WORKDIR /usr/src/boost_1_69_0
+RUN ./bootstrap.sh
+RUN sed -i 's/using gcc/using gcc : arm : arm-linux-gnueabihf-gcc/g' project-config.jam
+RUN ./b2 toolset=gcc-arm -j`nproc` abi=aapcs cxxstd=14 --with-regex --with-system --with-program_options --with-log --with-coroutine --with-test --prefix=/opt/arm/
+RUN ./b2 toolset=gcc-arm -j`nproc` abi=aapcs cxxstd=14 --with-regex --with-system --with-program_options --with-log --with-coroutine --with-test --prefix=/opt/arm/ install
+
+WORKDIR /usr/src/
+WORKDIR /usr/src/AqaraHub
+RUN mkdir build
+WORKDIR /usr/src/AqaraHub/build
+ADD armv7.cmake /
+RUN cmake -DCMAKE_TOOLCHAIN_FILE=/armv7.cmake ..
+RUN make -j`nproc`
+
+RUN mkdir /output
+RUN cp -v AqaraHub /output/
+RUN cp -v ../clusters.info /output/
+ENTRYPOINT tar --create /output

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: build-docker-arm
+build-docker-arm:
+	mkdir -p output
+	docker build -t aqarahub-armhf-build .
+	docker run --rm aqarahub-armhf-build | tar --extract --verbose

--- a/armv7.cmake
+++ b/armv7.cmake
@@ -1,0 +1,11 @@
+set (CMAKE_SYSTEM_NAME Linux)
+set (CMAKE_C_COMPILER arm-linux-gnueabihf-gcc)
+set (CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++)
+set (ENV{PKG_CONFIG_PATH} /opt/arm/lib/pkgconfig)
+
+set (CMAKE_FIND_ROOT_PATH /opt/arm/lib /opt/arm/include)
+set (THREADS_PREFER_PTHREAD_FLAG On) #https://gitlab.kitware.com/cmake/cmake/issues/16540
+set (BOOST_ROOT /usr/src/boost_1_69_0/)
+set (BOOST_INCLUDEDIR /opt/arm/include/boost)
+set (OPENSSL_INCLUDE_DIR /opt/arm/include)
+#set (OPENSSL_CRYPTO_LIBRARY /opt/arm/lib)


### PR DESCRIPTION
Warning: this is a mess, but it works
If I could work out how to do all of this as a CMake target I wouldn't need the Makefile.
You may want to rename the Makefile to Makefile.arm or something like that.

Requirements: x86_64 machine, docker and 2.1GB of space.

Run `make build-docker-arm` and wait for an hour or so. You'll get a binary in `output/` along with clusterdb.info

I'd like to change this to not build its own OpenSSL and also to be statically linked, but Boost gave me a whole lot of trouble.


