### PR TITLE
Make it possible to have write topic under different root topic

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -848,28 +848,29 @@ int main(int argc, const char** argv) {
                                    std::placeholders::_3));
   auto api = std::make_shared<znp::ZnpApi>(io_service, port);
 
-  LOG("Main", info) << "Setting up MQTT connection";
-
-  std::shared_ptr<MqttWrapper> mqtt_wrapper;
-  try {
-    mqtt_wrapper =
-        MqttWrapper::FromUrl(io_service, variables["mqtt"].as<std::string>());
-  } catch (const std::exception& ex) {
-    std::cerr << ex.what() << std::endl;
-    return EXIT_FAILURE;
-  }
-
   std::string mqtt_prefix = variables["topic"].as<std::string>();
   MakePrefixEndWithSlash(mqtt_prefix);
   LOG("Main", info) << "Using MQTT prefix '" << mqtt_prefix << "'";
   std::string mqtt_prefix_write = mqtt_prefix;
+
+  bool mqtt_recursive_publish = (variables.count("recursive-publish") > 0);
+  LOG("Main", info) << "Recursively publishing object and array properties";
+
   if (variables.count("write-topic") > 0) {
      mqtt_prefix_write = variables["write-topic"].as<std::string>();
   }
   MakePrefixEndWithSlash(mqtt_prefix_write);
   LOG("Main", info) << "Using MQTT prefix write '" << mqtt_prefix_write << "'";
-  bool mqtt_recursive_publish = (variables.count("recursive-publish") > 0);
-  LOG("Main", info) << "Recursively publishing object and array properties";
+
+  LOG("Main", info) << "Setting up MQTT connection";
+  std::shared_ptr<MqttWrapper> mqtt_wrapper;
+  try {
+    mqtt_wrapper =
+        MqttWrapper::FromUrl(io_service, variables["mqtt"].as<std::string>(), mqtt_prefix_write);
+  } catch (const std::exception& ex) {
+    std::cerr << ex.what() << std::endl;
+    return EXIT_FAILURE;
+  }
 
   // Creating pre-shared-key
   std::array<uint8_t, 16> presharedkey;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -706,7 +706,7 @@ std::shared_ptr<zcl::ZclEndpoint> Initialize(
       });
 
   api->zdo_on_permit_join_.connect(std::bind(
-      &OnPermitJoin, mqtt_wrapper, mqtt_prefix, std::placeholders::_1));
+      &OnPermitJoin, mqtt_wrapper, mqtt_prefix_write, std::placeholders::_1));
   api->af_on_incoming_msg_.connect(std::bind(
       &OnIncomingMsg, api, mqtt_wrapper, mqtt_prefix, std::placeholders::_1));
   api->zdo_on_trustcenter_device_.connect(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -782,7 +782,8 @@ int main(int argc, const char** argv) {
     ("topic,t",
      boost::program_options::value<std::string>()->default_value("AqaraHub"),
      "MQTT Root topic, e.g. AqaraHub")
-    ("topic-write,w",
+    ("write-topic,w",
+     boost::program_options::value<std::string>(),
      "Put write topic under different MQTT Root. This is useful for machines with multiple sticks, but wanting to publish as one.")
     ("panid",
      boost::program_options::value<uint16_t>()->default_value(0xFFFF),
@@ -862,8 +863,8 @@ int main(int argc, const char** argv) {
   MakePrefixEndWithSlash(mqtt_prefix);
   LOG("Main", info) << "Using MQTT prefix '" << mqtt_prefix << "'";
   std::string mqtt_prefix_write = mqtt_prefix;
-  if (variables.count("topic-write") > 0) {
-     mqtt_prefix_write = variables["topic-write"].as<std::string>();
+  if (variables.count("write-topic") > 0) {
+     mqtt_prefix_write = variables["write-topic"].as<std::string>();
   }
   MakePrefixEndWithSlash(mqtt_prefix_write);
   LOG("Main", info) << "Using MQTT prefix write '" << mqtt_prefix_write << "'";

--- a/src/mqtt_wrapper.cpp
+++ b/src/mqtt_wrapper.cpp
@@ -1,9 +1,6 @@
 #include "mqtt_wrapper.h"
 #include <boost/optional/optional_io.hpp>
-#include <boost/lexical_cast.hpp>
 #include <regex>
-#include <limits>
-#include <cstdlib>
 #include "mqtt_wrapper_impl.h"
 #include "uri_parser.h"
 
@@ -96,8 +93,7 @@ std::shared_ptr<MqttWrapper> MqttWrapper::FromParameters(
     MqttWrapper::Parameters params,
     std::string mqtt_prefix_write) {
   params.port = params.port ? *params.port : "1883";
-  params.client_id = params.client_id ? *params.client_id
-         : "AqaraHub-"+mqtt_prefix_write+"-"+boost::lexical_cast<std::string>(rand());
+  params.client_id = params.client_id ? *params.client_id : "AqaraHub-"+mqtt_prefix_write;
 
   LOG("MqttWrapper", info)
         << "Params: " << params;

--- a/src/mqtt_wrapper.cpp
+++ b/src/mqtt_wrapper.cpp
@@ -91,6 +91,8 @@ boost::optional<MqttWrapper::Parameters> MqttWrapper::ParseUrl(
 std::shared_ptr<MqttWrapper> MqttWrapper::FromParameters(
     boost::asio::io_service& io_service,
     const MqttWrapper::Parameters& params) {
+  std::string aport = params.port ? *params.port : "1883";
+  std::string aclient_id = params.client_id ? *params.client_id : "AqaraHub";
   if (params.use_ws) {
 #if defined(MQTT_USE_WS)
     if (params.use_tls) {
@@ -105,8 +107,8 @@ std::shared_ptr<MqttWrapper> MqttWrapper::FromParameters(
             if (password) client->set_password(*password);
             return client;
           },
-          io_service, params.hostname, (params.port ? *params.port : "1883"),
-          (params.client_id ? *params.client_id : "AqaraHub"), params.username,
+          io_service, params.hostname, aport,
+          aclient_id, params.username,
           params.password);
     } else {
       return CreateMqttWrapperImpl(
@@ -120,8 +122,8 @@ std::shared_ptr<MqttWrapper> MqttWrapper::FromParameters(
             if (password) client->set_password(*password);
             return client;
           },
-          io_service, params.hostname, (params.port ? *params.port : "1883"),
-          (params.client_id ? *params.client_id : "AqaraHub"), params.username,
+          io_service, params.hostname, aport,
+          aclient_id, params.username,
           params.password);
     }
 #else
@@ -141,8 +143,8 @@ std::shared_ptr<MqttWrapper> MqttWrapper::FromParameters(
             if (password) client->set_password(*password);
             return client;
           },
-          io_service, params.hostname, (params.port ? *params.port : "1883"),
-          (params.client_id ? *params.client_id : "AqaraHub"), params.username,
+          io_service, params.hostname, aport,
+          aclient_id, params.username,
           params.password);
     } else {
       return CreateMqttWrapperImpl(
@@ -156,8 +158,8 @@ std::shared_ptr<MqttWrapper> MqttWrapper::FromParameters(
             if (password) client->set_password(*password);
             return client;
           },
-          io_service, params.hostname, (params.port ? *params.port : "1883"),
-          (params.client_id ? *params.client_id : "AqaraHub"), params.username,
+          io_service, params.hostname, aport,
+          aclient_id, params.username,
           params.password);
     }
   }

--- a/src/mqtt_wrapper.h
+++ b/src/mqtt_wrapper.h
@@ -32,9 +32,9 @@ class MqttWrapper {
 
   static boost::optional<Parameters> ParseUrl(const std::string& url);
   static std::shared_ptr<MqttWrapper> FromUrl(
-      boost::asio::io_service& io_service, std::string url);
+      boost::asio::io_service& io_service, std::string url, std::string mqtt_prefix_write);
   static std::shared_ptr<MqttWrapper> FromParameters(
-      boost::asio::io_service& io_service, const Parameters& params);
+      boost::asio::io_service& io_service, Parameters params, std::string mqtt_prefix_write);
 };
 
 std::ostream& operator<<(std::ostream& s,


### PR DESCRIPTION
I have too many sensors to connect to one CC2531, so this allow me to have two CC2531, but both sticks to publish under the same MQTT root topic, so from consumer point of view, it does not matter which stick the end device is joined to. Also allows moving device from one stick to the other without any impact to consumers. Having ability to have write topic under its own root, means, that I can control which stick the new device joins to.